### PR TITLE
Add medication supply tracking and refill management

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Ensure consistent line endings (LF) for all text files
+* text=auto eol=lf
+
+# Explicitly set text files
+*.py text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+*.md text eol=lf
+*.txt text eol=lf
+*.html text eol=lf
+*.css text eol=lf
+
+# Binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary

--- a/custom_components/medication_tracker/binary_sensor.py
+++ b/custom_components/medication_tracker/binary_sensor.py
@@ -14,7 +14,17 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, STATE_DUE, STATE_OVERDUE, STATE_SKIPPED
+from .const import (
+    ATTR_CURRENT_SUPPLY,
+    ATTR_DAYS_REMAINING,
+    ATTR_ESTIMATED_REFILL_DATE,
+    ATTR_PILLS_PER_DOSE,
+    ATTR_REFILL_THRESHOLD_DAYS,
+    DOMAIN,
+    STATE_DUE,
+    STATE_OVERDUE,
+    STATE_SKIPPED,
+)
 from .coordinator import MedicationCoordinator
 from .models import MedicationEntry
 
@@ -35,6 +45,9 @@ async def async_setup_entry(
         medications = coordinator.data.get("medications", {})
         for medication_id, medication in medications.items():
             entities.append(MedicationDueSensor(coordinator, medication_id, medication))
+            entities.append(
+                MedicationLowSupplySensor(coordinator, medication_id, medication)
+            )
 
     async_add_entities(entities)
 
@@ -43,7 +56,10 @@ async def async_setup_entry(
         medication_id: str, medication: MedicationEntry
     ) -> None:
         """Create entities for a new medication."""
-        new_entities = [MedicationDueSensor(coordinator, medication_id, medication)]
+        new_entities = [
+            MedicationDueSensor(coordinator, medication_id, medication),
+            MedicationLowSupplySensor(coordinator, medication_id, medication),
+        ]
         async_add_entities(new_entities)
 
     coordinator.register_entity_creation_callback(
@@ -113,5 +129,91 @@ class MedicationDueSensor(CoordinatorEntity, BinarySensorEntity):
 
         if medication.data.end_date:
             attributes["end_date"] = medication.data.end_date.isoformat()
+
+        return attributes
+
+
+class MedicationLowSupplySensor(CoordinatorEntity, BinarySensorEntity):
+    """Binary sensor for medication low supply status."""
+
+    def __init__(
+        self,
+        coordinator: MedicationCoordinator,
+        medication_id: str,
+        medication: MedicationEntry,
+    ) -> None:
+        """Initialize the binary sensor."""
+        super().__init__(coordinator)
+        self._medication_id = medication_id
+        self._medication = medication
+        self._attr_unique_id = f"{DOMAIN}_{medication_id}_low_supply"
+        self._attr_name = f"{medication.data.name} Low Supply"
+        self._attr_icon = "mdi:pill-off"
+        self._attr_device_class = BinarySensorDeviceClass.PROBLEM
+        # Associate with the medication device
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, medication.device_id)},
+            "name": f"{medication.data.name} Medication",
+            "manufacturer": "Home Assistant",
+            "model": "Medication Tracker",
+            "suggested_area": "Medicine Cabinet",
+        }
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available (only if supply tracking enabled)."""
+        if not self.coordinator.data:
+            return False
+        medications = self.coordinator.data.get("medications", {})
+        if self._medication_id not in medications:
+            return False
+        medication = medications[self._medication_id]
+        return medication.data.supply_tracking_enabled
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if medication supply is low."""
+        if self.coordinator.data:
+            medications = self.coordinator.data.get("medications", {})
+            if self._medication_id in medications:
+                medication = medications[self._medication_id]
+                return medication.is_low_supply
+        return False
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the state attributes."""
+        if not self.coordinator.data:
+            return {}
+
+        medications = self.coordinator.data.get("medications", {})
+        if self._medication_id not in medications:
+            return {}
+
+        medication = medications[self._medication_id]
+        attributes = {
+            "medication_name": medication.data.name,
+            "supply_tracking_enabled": medication.data.supply_tracking_enabled,
+        }
+
+        if medication.data.supply_tracking_enabled:
+            attributes[ATTR_CURRENT_SUPPLY] = medication.data.current_supply
+            attributes[ATTR_PILLS_PER_DOSE] = medication.data.pills_per_dose
+            attributes[ATTR_REFILL_THRESHOLD_DAYS] = (
+                medication.data.refill_reminder_threshold
+            )
+
+            days_remaining = medication.days_of_supply_remaining
+            if days_remaining is not None:
+                attributes[ATTR_DAYS_REMAINING] = round(days_remaining, 1)
+
+            refill_date = medication.estimated_refill_date
+            if refill_date:
+                attributes[ATTR_ESTIMATED_REFILL_DATE] = refill_date.isoformat()
+
+            if medication.data.last_refill_date:
+                attributes["last_refill_date"] = (
+                    medication.data.last_refill_date.isoformat()
+                )
 
         return attributes

--- a/custom_components/medication_tracker/binary_sensor.py
+++ b/custom_components/medication_tracker/binary_sensor.py
@@ -202,6 +202,9 @@ class MedicationLowSupplySensor(CoordinatorEntity, BinarySensorEntity):
             attributes[ATTR_REFILL_THRESHOLD_DAYS] = (
                 medication.data.refill_reminder_threshold
             )
+            attributes["show_refill_on_calendar"] = (
+                medication.data.show_refill_on_calendar
+            )
 
             days_remaining = medication.days_of_supply_remaining
             if days_remaining is not None:

--- a/custom_components/medication_tracker/const.py
+++ b/custom_components/medication_tracker/const.py
@@ -16,6 +16,14 @@ CONF_START_DATE: Final = "start_date"
 CONF_END_DATE: Final = "end_date"
 CONF_NOTES: Final = "notes"
 
+# Supply tracking configuration constants
+CONF_SUPPLY_TRACKING_ENABLED: Final = "supply_tracking_enabled"
+CONF_CURRENT_SUPPLY: Final = "current_supply"
+CONF_PILLS_PER_DOSE: Final = "pills_per_dose"
+CONF_REFILL_REMINDER_THRESHOLD: Final = "refill_reminder_threshold"
+CONF_LAST_REFILL_DATE: Final = "last_refill_date"
+CONF_SHOW_REFILL_ON_CALENDAR: Final = "show_refill_on_calendar"
+
 # Frequency options
 FREQUENCY_DAILY: Final = "daily"
 FREQUENCY_WEEKLY: Final = "weekly"
@@ -28,6 +36,8 @@ SERVICE_SKIP_MEDICATION: Final = "skip_medication"
 SERVICE_ADD_MEDICATION: Final = "add_medication"
 SERVICE_REMOVE_MEDICATION: Final = "remove_medication"
 SERVICE_UPDATE_MEDICATION: Final = "update_medication"
+SERVICE_REFILL_MEDICATION: Final = "refill_medication"
+SERVICE_UPDATE_SUPPLY: Final = "update_supply"
 
 # Attributes
 ATTR_MEDICATION_ID: Final = "medication_id"
@@ -39,6 +49,15 @@ ATTR_NEXT_DUE: Final = "next_due"
 ATTR_LAST_TAKEN: Final = "last_taken"
 ATTR_MISSED_DOSES: Final = "missed_doses"
 ATTR_ADHERENCE_RATE: Final = "adherence_rate"
+
+# Supply tracking attributes
+ATTR_CURRENT_SUPPLY: Final = "current_supply"
+ATTR_PILLS_PER_DOSE: Final = "pills_per_dose"
+ATTR_REFILL_AMOUNT: Final = "refill_amount"
+ATTR_DAYS_REMAINING: Final = "days_remaining"
+ATTR_ESTIMATED_REFILL_DATE: Final = "estimated_refill_date"
+ATTR_DAILY_CONSUMPTION: Final = "daily_consumption"
+ATTR_REFILL_THRESHOLD_DAYS: Final = "refill_threshold_days"
 
 # Device info
 DEVICE_MODEL: Final = "Medication Tracker"
@@ -53,3 +72,4 @@ STATE_SKIPPED: Final = "skipped"
 
 # Events
 EVENT_MEDICATION_STATE_CHANGED: Final = "medication_tracker_state_changed"
+EVENT_MEDICATION_LOW_SUPPLY: Final = "medication_tracker_low_supply"

--- a/custom_components/medication_tracker/coordinator.py
+++ b/custom_components/medication_tracker/coordinator.py
@@ -284,7 +284,7 @@ class MedicationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def async_refill_medication(
         self,
         medication_id: str,
-        refill_amount: int,
+        refill_amount: float,
         refill_date: datetime | None = None,
     ) -> bool:
         """Refill medication supply."""

--- a/custom_components/medication_tracker/models.py
+++ b/custom_components/medication_tracker/models.py
@@ -37,7 +37,7 @@ class MedicationData:
     # Supply tracking fields
     supply_tracking_enabled: bool = False
     current_supply: int | None = None
-    pills_per_dose: int = 1
+    pills_per_dose: float = 1.0
     refill_reminder_threshold: int = 7  # days worth of supply before alerting
     last_refill_date: date | datetime | None = None
     show_refill_on_calendar: bool = False

--- a/custom_components/medication_tracker/models.py
+++ b/custom_components/medication_tracker/models.py
@@ -36,7 +36,7 @@ class MedicationData:
     notes: str = ""
     # Supply tracking fields
     supply_tracking_enabled: bool = False
-    current_supply: int | None = None
+    current_supply: float | None = None
     pills_per_dose: float = 1.0
     refill_reminder_threshold: int = 7  # days worth of supply before alerting
     last_refill_date: date | datetime | None = None

--- a/custom_components/medication_tracker/panel/static/medication-tracker-panel.js
+++ b/custom_components/medication_tracker/panel/static/medication-tracker-panel.js
@@ -1657,10 +1657,11 @@ class MedicationTrackerPanel extends LitElement {
                       <input
                         class="form-input"
                         type="number"
-                        min="1"
+                        min="0.1"
+                        step="any"
                         .value=${this._newMedication.pills_per_dose}
                         @input=${(e) =>
-              this._updateNewMedication("pills_per_dose", parseInt(e.target.value) || 1)}
+              this._updateNewMedication("pills_per_dose", parseFloat(e.target.value) || 1)}
                       />
                     </div>
 
@@ -1864,10 +1865,11 @@ class MedicationTrackerPanel extends LitElement {
                       <input
                         class="form-input"
                         type="number"
-                        min="1"
+                        min="0.1"
+                        step="any"
                         .value=${this._editMedication.pills_per_dose}
                         @input=${(e) =>
-              this._updateEditMedication("pills_per_dose", parseInt(e.target.value) || 1)}
+              this._updateEditMedication("pills_per_dose", parseFloat(e.target.value) || 1)}
                       />
                     </div>
 

--- a/custom_components/medication_tracker/sensor.py
+++ b/custom_components/medication_tracker/sensor.py
@@ -333,4 +333,7 @@ class MedicationSupplySensor(CoordinatorEntity, SensorEntity):
         if medication.data.last_refill_date:
             attributes["last_refill_date"] = medication.data.last_refill_date.isoformat()
 
+        attributes["refill_threshold_days"] = medication.data.refill_reminder_threshold
+        attributes["show_refill_on_calendar"] = medication.data.show_refill_on_calendar
+
         return attributes

--- a/custom_components/medication_tracker/services.py
+++ b/custom_components/medication_tracker/services.py
@@ -78,8 +78,8 @@ ADD_MEDICATION_SCHEMA = vol.Schema(
         vol.Optional(CONF_NOTES, default=""): cv.string,
         # Supply tracking fields
         vol.Optional(CONF_SUPPLY_TRACKING_ENABLED, default=False): cv.boolean,
-        vol.Optional(CONF_CURRENT_SUPPLY): cv.positive_int,
-        vol.Optional(CONF_PILLS_PER_DOSE, default=1): cv.positive_int,
+        vol.Optional(CONF_CURRENT_SUPPLY): vol.Coerce(float),
+        vol.Optional(CONF_PILLS_PER_DOSE, default=1.0): vol.Coerce(float),
         vol.Optional(CONF_REFILL_REMINDER_THRESHOLD, default=7): cv.positive_int,
         vol.Optional(CONF_SHOW_REFILL_ON_CALENDAR, default=False): cv.boolean,
     }
@@ -110,8 +110,8 @@ UPDATE_MEDICATION_SCHEMA = vol.Schema(
         vol.Optional(CONF_NOTES): cv.string,
         # Supply tracking fields
         vol.Optional(CONF_SUPPLY_TRACKING_ENABLED): cv.boolean,
-        vol.Optional(CONF_CURRENT_SUPPLY): cv.positive_int,
-        vol.Optional(CONF_PILLS_PER_DOSE): cv.positive_int,
+        vol.Optional(CONF_CURRENT_SUPPLY): vol.Coerce(float),
+        vol.Optional(CONF_PILLS_PER_DOSE): vol.Coerce(float),
         vol.Optional(CONF_REFILL_REMINDER_THRESHOLD): cv.positive_int,
         vol.Optional(CONF_SHOW_REFILL_ON_CALENDAR): cv.boolean,
     }
@@ -120,7 +120,7 @@ UPDATE_MEDICATION_SCHEMA = vol.Schema(
 REFILL_MEDICATION_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_MEDICATION_ID): cv.string,
-        vol.Required(ATTR_REFILL_AMOUNT): cv.positive_int,
+        vol.Required(ATTR_REFILL_AMOUNT): vol.Coerce(float),
         vol.Optional(ATTR_DATETIME): cv.datetime,
     }
 )
@@ -128,7 +128,7 @@ REFILL_MEDICATION_SCHEMA = vol.Schema(
 UPDATE_SUPPLY_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_MEDICATION_ID): cv.string,
-        vol.Required(ATTR_CURRENT_SUPPLY): cv.positive_int,
+        vol.Required(ATTR_CURRENT_SUPPLY): vol.Coerce(float),
     }
 )
 

--- a/custom_components/medication_tracker/services.yaml
+++ b/custom_components/medication_tracker/services.yaml
@@ -106,7 +106,8 @@ add_medication:
       default: 1
       selector:
         number:
-          min: 1
+          min: 0.1
+          step: 0.1
           mode: box
     refill_reminder_threshold:
       name: Refill Reminder Threshold
@@ -214,7 +215,8 @@ update_medication:
       required: false
       selector:
         number:
-          min: 1
+          min: 0.1
+          step: 0.1
           mode: box
     refill_reminder_threshold:
       name: Refill Reminder Threshold

--- a/custom_components/medication_tracker/services.yaml
+++ b/custom_components/medication_tracker/services.yaml
@@ -84,6 +84,46 @@ add_medication:
       selector:
         text:
           multiline: true
+    supply_tracking_enabled:
+      name: Enable Supply Tracking
+      description: Enable supply tracking for this medication.
+      required: false
+      default: false
+      selector:
+        boolean:
+    current_supply:
+      name: Current Supply
+      description: Current number of units in stock.
+      required: false
+      selector:
+        number:
+          min: 0
+          mode: box
+    pills_per_dose:
+      name: Units Per Dose
+      description: Number of units taken per dose.
+      required: false
+      default: 1
+      selector:
+        number:
+          min: 1
+          mode: box
+    refill_reminder_threshold:
+      name: Refill Reminder Threshold
+      description: Days of supply remaining before triggering low supply alert.
+      required: false
+      default: 7
+      selector:
+        number:
+          min: 1
+          mode: box
+    show_refill_on_calendar:
+      name: Show Refill on Calendar
+      description: Display estimated refill date on the medication calendar.
+      required: false
+      default: false
+      selector:
+        boolean:
 
 remove_medication:
   name: Remove Medication
@@ -154,3 +194,83 @@ update_medication:
       selector:
         text:
           multiline: true
+    supply_tracking_enabled:
+      name: Enable Supply Tracking
+      description: Enable or disable supply tracking (optional - will keep existing if not provided).
+      required: false
+      selector:
+        boolean:
+    current_supply:
+      name: Current Supply
+      description: Current number of units in stock (optional - will keep existing if not provided).
+      required: false
+      selector:
+        number:
+          min: 0
+          mode: box
+    pills_per_dose:
+      name: Units Per Dose
+      description: Number of units taken per dose (optional - will keep existing if not provided).
+      required: false
+      selector:
+        number:
+          min: 1
+          mode: box
+    refill_reminder_threshold:
+      name: Refill Reminder Threshold
+      description: Days of supply remaining before triggering low supply alert (optional - will keep existing if not provided).
+      required: false
+      selector:
+        number:
+          min: 1
+          mode: box
+    show_refill_on_calendar:
+      name: Show Refill on Calendar
+      description: Display estimated refill date on the medication calendar (optional - will keep existing if not provided).
+      required: false
+      selector:
+        boolean:
+
+refill_medication:
+  name: Refill Medication
+  description: Add units to a medication's supply.
+  fields:
+    medication_id:
+      name: Medication ID
+      description: The ID of the medication to refill.
+      required: true
+      selector:
+        text:
+    refill_amount:
+      name: Refill Amount
+      description: The number of units to add to the supply.
+      required: true
+      selector:
+        number:
+          min: 1
+          mode: box
+    datetime:
+      name: Refill Date
+      description: When the refill occurred (optional - defaults to now).
+      required: false
+      selector:
+        datetime:
+
+update_supply:
+  name: Update Supply
+  description: Manually set a medication's current supply count.
+  fields:
+    medication_id:
+      name: Medication ID
+      description: The ID of the medication to update.
+      required: true
+      selector:
+        text:
+    current_supply:
+      name: Current Supply
+      description: The new supply count.
+      required: true
+      selector:
+        number:
+          min: 0
+          mode: box

--- a/custom_components/medication_tracker/services.yaml
+++ b/custom_components/medication_tracker/services.yaml
@@ -98,6 +98,7 @@ add_medication:
       selector:
         number:
           min: 0
+          step: 0.5
           mode: box
     pills_per_dose:
       name: Units Per Dose
@@ -106,8 +107,8 @@ add_medication:
       default: 1
       selector:
         number:
-          min: 0.1
-          step: 0.1
+          min: 0.5
+          step: 0.5
           mode: box
     refill_reminder_threshold:
       name: Refill Reminder Threshold
@@ -208,6 +209,7 @@ update_medication:
       selector:
         number:
           min: 0
+          step: 0.5
           mode: box
     pills_per_dose:
       name: Units Per Dose
@@ -215,8 +217,8 @@ update_medication:
       required: false
       selector:
         number:
-          min: 0.1
-          step: 0.1
+          min: 0.5
+          step: 0.5
           mode: box
     refill_reminder_threshold:
       name: Refill Reminder Threshold
@@ -249,7 +251,8 @@ refill_medication:
       required: true
       selector:
         number:
-          min: 1
+          min: 0.5
+          step: 0.5
           mode: box
     datetime:
       name: Refill Date
@@ -275,4 +278,5 @@ update_supply:
       selector:
         number:
           min: 0
+          step: 0.5
           mode: box

--- a/custom_components/medication_tracker/translations/en.json
+++ b/custom_components/medication_tracker/translations/en.json
@@ -78,6 +78,88 @@
           "description": "The ID of the medication to remove."
         }
       }
+    },
+    "update_medication": {
+      "name": "Update Medication",
+      "description": "Update an existing medication's information.",
+      "fields": {
+        "medication_id": {
+          "name": "Medication ID",
+          "description": "The ID of the medication to update."
+        },
+        "name": {
+          "name": "Medication Name",
+          "description": "The name of the medication."
+        },
+        "dosage": {
+          "name": "Dosage",
+          "description": "The dosage information."
+        },
+        "frequency": {
+          "name": "Frequency",
+          "description": "How often to take the medication."
+        },
+        "times": {
+          "name": "Times",
+          "description": "Times to take the medication."
+        },
+        "notes": {
+          "name": "Notes",
+          "description": "Optional notes about the medication."
+        },
+        "supply_tracking_enabled": {
+          "name": "Enable Supply Tracking",
+          "description": "Enable supply tracking for this medication."
+        },
+        "current_supply": {
+          "name": "Current Supply",
+          "description": "Current number of units in stock."
+        },
+        "pills_per_dose": {
+          "name": "Units Per Dose",
+          "description": "Number of units taken per dose."
+        },
+        "refill_reminder_threshold": {
+          "name": "Refill Reminder Threshold",
+          "description": "Days of supply remaining before triggering low supply alert."
+        },
+        "show_refill_on_calendar": {
+          "name": "Show Refill on Calendar",
+          "description": "Display estimated refill date on the medication calendar."
+        }
+      }
+    },
+    "refill_medication": {
+      "name": "Refill Medication",
+      "description": "Add units to a medication's supply.",
+      "fields": {
+        "medication_id": {
+          "name": "Medication ID",
+          "description": "The ID of the medication to refill."
+        },
+        "refill_amount": {
+          "name": "Refill Amount",
+          "description": "The number of units to add to the supply."
+        },
+        "datetime": {
+          "name": "Refill Date",
+          "description": "When the refill occurred (optional - defaults to now)."
+        }
+      }
+    },
+    "update_supply": {
+      "name": "Update Supply",
+      "description": "Manually set a medication's current supply count.",
+      "fields": {
+        "medication_id": {
+          "name": "Medication ID",
+          "description": "The ID of the medication to update."
+        },
+        "current_supply": {
+          "name": "Current Supply",
+          "description": "The new supply count."
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Hi, I really love your custom component and I saw that supply tracking is on the "would be nice" list and I really could use that feature. I gave it a first stab. Happy to change whatever you suppose needs changing. Let me know.

## Summary

  - Add supply tracking for medications with current count, units per dose, and refill reminders
  - Track supply automatically - decrements when doses are taken
  - Low supply alerts via binary sensor and Home Assistant events
  - New Supplies Overview section in the panel showing all tracked supplies at a glance

  ## New Features

  Supply Tracking:
  - Enable per-medication supply tracking with current unit count
  - Configure units per dose and refill reminder threshold (days before empty)
  - Auto-decrement supply when marking doses as taken
  - Optional display of estimated refill date on calendar

  New Services:
  - medication_tracker.refill_medication - Add units to a medication's supply
  - medication_tracker.update_supply - Manually set current supply count

  New Entities (per medication):
  - sensor.{medication}_supply - Current supply count with days remaining
  - binary_sensor.{medication}_low_supply - ON when supply is running low

  Panel Updates:
  - Supplies Overview section at top of panel (collapsible table view)
  - Supply info on medication cards when enabled
  - Low supply warning badges
  - Quick refill button and dialog

  ## Test Plan

 - [x] Add a medication with supply tracking enabled
 - [x] Verify supply decrements when taking a dose
 - [x] Verify low supply warning appears when days remaining falls below threshold
 - [x] Test refill service adds units correctly
 - [x] Verify Supplies Overview section displays and sorts by urgency